### PR TITLE
Fix Manhattan distance label for p=1

### DIFF
--- a/DM_CW_Part_1 (2).ipynb
+++ b/DM_CW_Part_1 (2).ipynb
@@ -2180,7 +2180,7 @@
         "recall = recall_score(test_encoded_labels, ed_pred, pos_label=1)\n",
         "f1 = f1_score(test_encoded_labels, ed_pred, pos_label=1)\n",
         "\n",
-        "print(f\"Results for Minkowski distance with p=1 (Euclidean Distance):\")\n",
+        "print(f\"Results for Minkowski distance with p=1 (Manhattan Distance):\")\n",
         "print(f\"Accuracy: {accuracy}\")\n",
         "print(f\"Precision: {precision}\")\n",
         "print(f\"Recall: {recall}\")\n",
@@ -2200,7 +2200,7 @@
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "Results for Minkowski distance with p=1 (Euclidean Distance):\n",
+            "Results for Minkowski distance with p=1 (Manhattan Distance):\n",
             "Accuracy: 0.927536231884058\n",
             "Precision: 0.9655172413793104\n",
             "Recall: 0.875\n",


### PR DESCRIPTION
## Summary
- Correct distance label to "Minkowski distance with p=1 (Manhattan Distance)" in DM_CW_Part_1 (2).ipynb.

## Testing
- `pytest` (no tests ran)
- `pre-commit run --files "DM_CW_Part_1 (2).ipynb"` *(command not found)*
- `pip install pre-commit` *(failed: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_689a1764ae608322908fe1abc75734f5