### PR TITLE
Add test for nearest neighbour classification

### DIFF
--- a/nearest_neighbour.py
+++ b/nearest_neighbour.py
@@ -1,0 +1,11 @@
+def minkowski_distance(x, y, p):
+    return sum(abs(a - b) ** p for a, b in zip(x, y)) ** (1 / p)
+
+
+def nearest_neighbour_classification(training_features, training_labels, testing_features, p):
+    predictions = []
+    for test_point in testing_features:
+        distances = [minkowski_distance(test_point, train_point, p) for train_point in training_features]
+        nearest_index = distances.index(min(distances))
+        predictions.append(training_labels[nearest_index])
+    return predictions

--- a/tests/test_nearest_neighbour.py
+++ b/tests/test_nearest_neighbour.py
@@ -1,0 +1,8 @@
+from nearest_neighbour import nearest_neighbour_classification
+
+def test_nearest_neighbour_classification():
+    training_features = [[0.0, 0.0], [1.0, 1.0]]
+    training_labels = ["A", "B"]
+    query = [[0.1, 0.1]]
+    prediction = nearest_neighbour_classification(training_features, training_labels, query, p=2)
+    assert prediction == ["A"]


### PR DESCRIPTION
## Summary
- add simple nearest neighbour classifier implementation
- add unit test verifying prediction of nearest training label

## Testing
- `python3 - <<'PY'
from tests.test_nearest_neighbour import test_nearest_neighbour_classification
try:
    test_nearest_neighbour_classification()
    print('test passed')
except AssertionError as e:
    print('test failed', e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_689a1769617483228a9fbb0a2a31dda9